### PR TITLE
Navigation and proposed changes

### DIFF
--- a/docs/features/features_android.md
+++ b/docs/features/features_android.md
@@ -1,4 +1,6 @@
-# Android accessibility features overview
+[← Accessibility features per mobile platform](features_mobile_platforms.md "Accessibility features per mobile platform")
+
+# Accessibility features on Android
 
 It is very important that the app you are developing is accessible to all users. Accessibility should be considered during the whole development process. If properly implemented, accessibility features and services can significantly improve your app's usability especially for users with disabilities, but also in general.
 
@@ -109,5 +111,4 @@ There are three different types of switches:
 Detailed description of all Switch Access configuration could be found on the official [Android Accessibility Help - Switch Access page](https://support.google.com/accessibility/android/answer/6122836?hl=en&ref_topic=6151780).
 
 
-
-
+[← Accessibility features per mobile platform](features_mobile_platforms.md "Accessibility features per mobile platform")

--- a/docs/features/features_flutter.md
+++ b/docs/features/features_flutter.md
@@ -1,3 +1,5 @@
+[← Accessibility features per mobile platform](features_mobile_platforms.md "Accessibility features per mobile platform")
+
 # Accessibility features in Flutter
 
 ## Determining accessibility

--- a/docs/features/features_ios.md
+++ b/docs/features/features_ios.md
@@ -1,4 +1,5 @@
 [← Accessibility features per mobile platform](features_mobile_platforms.md "Accessibility features per mobile platform")
+
 # Accessibility features on iOS
 
 ## The fundamentals

--- a/docs/features/features_ios.md
+++ b/docs/features/features_ios.md
@@ -1,3 +1,4 @@
+[← Accessibility features per mobile platform](features_mobile_platforms.md "Accessibility features per mobile platform")
 # Accessibility features on iOS
 
 ## The fundamentals

--- a/docs/features/features_mobile_platforms.md
+++ b/docs/features/features_mobile_platforms.md
@@ -2,7 +2,7 @@
 
 Mobile standards provide information about accessibility features and implementation for the following platforms:
 
-* Android
+* [Android](features_android.md "Accessibility features for Android")
 * [iOS](features_ios.md "Accessibility features on iOS")
 * [Flutter](features_flutter.md "Accessibility features in Flutter")
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -1,10 +1,13 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
 # Operable guidelines for Android
 
-_User interface components and navigation must be operable._
+User interface components and navigation must be operable.
 
 ## Keyboard accessible
 
-_Make all functionality available from a keyboard._
+Make all functionality available from a keyboard.
+
+*This guideline covers point 2.1.1 Keyboard - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -69,15 +72,13 @@ When the user is navigating through the app **using arrow keys on the keyboard**
 
 - not defining custom order if the views in the layout file are not defined in the same order they should be presented to the user
 
-#### Additional notes
-
-This guideline covers point 2.1.1 Keyboard - Level A of the WCAG standard.
-
 ---
 
 ## Enough time
 
-_Provide users enough time to read and use content._
+Provide users enough time to read and use content.
+
+*This guideline covers point 2.2.1 Timing Adjustable - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -93,15 +94,13 @@ All users should have the ability to interact with the content displayed on the 
 
 - define time-limited actions in the app with no ability to extend that limit
 
-#### Additional notes
-
-This guideline covers point 2.2.1 Timing Adjustable - Level A of the WCAG standard.
-
 ---
 
 ### Pause, Stop, Hide
 
 Moving, blinking, or scrolling, or auto-updating content in the app.
+
+*This guideline covers point 2.2.2 Pause, Stop Hide - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -115,19 +114,17 @@ Moving, blinking, or scrolling, or auto-updating content in the app.
 
 - Using an auto-updating or auto-scrolling view that can't be paused/stopped.
 
-#### Additional notes
-
-This guideline covers point 2.2.2 Pause, Stop Hide - Level A of the WCAG standard.
-
 ---
 
 ## Seizures and Physical Reactions
 
-_Do not design content in a way that is known to cause seizures or physical reactions._
+Do not design content in a way that is known to cause seizures or physical reactions.
 
 ### Three Flashed or Below Treshold
 
 Apps should not contain elements that flash more than three times in one second period.
+
+*This guideline covers point 2.3.1 - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -143,17 +140,15 @@ Apps should not contain elements that flash more than three times in one second 
 
 - Having a larger area of screen flashing more than three times per second
 
-#### Additional notes
-
-This guideline covers point 2.3.1 - Level A of the WCAG standard.
-
 ---
 
 ## Navigable
 
-_Provide ways to help users navigate, find content, and determine where they are._
+Provide ways to help users navigate, find content, and determine where they are.
 
 ### Bypass Blocks
+
+*This guideline covers points 2.4.1 Bypass Blocks - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -209,13 +204,11 @@ ViewCompat.setAccessibilityDelegate(personalData, object : AccessibilityDelegate
 
 - user of accessibility services has to navigate through all the items displayed on the screen with no possibility to fasten the navigation process
 
-#### Additional notes
-
-This guideline covers points 2.4.1 Bypass Blocks - Level A of the WCAG standard.
-
 ---
 
 ### Page Titles
+
+*This guideline covers point 2.4.2 Page Titled - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -229,13 +222,11 @@ If the title is defined using a toolbar with custom behavior or some other custo
 
 - defined titles are not the first elements that are read when user enters the screen and therefore users using accessibility services have no information which screen they opened
 
-#### Additional notes
-
-This guideline covers point 2.4.2 Page Titled - Level A of the WCAG standard.
-
 ---
 
 ### Focus Order
+
+*This guideline covers point 2.4.3 Focus Order - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -247,13 +238,11 @@ Defining the content of the screen in the meaningful sequence described in the [
 
 - views displayed on the screen break consistency of navigation
 
-#### Additional notes
-
-This guideline covers point 2.4.3 Focus Order - Level A of the WCAG standard.
-
 ---
 
 ### Link Purpose
+
+*This guideline covers point 2.4.4 Link Purpose (In Context) - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -290,10 +279,6 @@ Example given on the **Screenshot 4.** - **Avoid using ClickableSpan** and inste
 - link is defined as unclear label or button and has no additional description provided
 
 - link is part of the longer text and implemented using ClickableSpan so TalkBack users are not aware of link existence
-
-#### Additional notes
-
-This guideline covers point 2.4.4 Link Purpose (In Context) - Level A of the WCAG standard.
 
 ---
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
 # Operable guidelines for Android
 
 User interface components and navigation must be operable.

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
 # Perceivable guidelines for Android
 
 All content displayed on the screen at some point must be presented to the user in a perceivable manner.

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -1,10 +1,13 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
 # Perceivable guidelines for Android
 
 All content displayed on the screen at some point must be presented to the user in a perceivable manner.
 
 ## Text alternatives
 
-_Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language._
+Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.
+
+*This guideline covers point 1.1.1 Non-text Content - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -18,15 +21,13 @@ If an element exists on the UI only for decorative purposes it is recommended th
 
 - Not providing descriptions of elements presented on the screen that do not exist only for decorative purposes
 
-#### Additional notes
-
-This guideline covers point 1.1.1 Non-text Content - Level A of the WCAG standard.
-
 ---
 
 ## Time-based Media
 
-_Provide alternatives for time-based media._
+Provide alternatives for time-based media.
+
+*This guideline covers point 1.2 Time-Based Media - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -40,17 +41,17 @@ If the app you are building includes media content such as video clips or audio 
 
 - all media is presented to the user without the possibility to change some of the controls (slow down, pause, volume up etc.)
 
-#### Additional notes
-
-This guideline covers point 1.2 Time-Based Media - Level A of the WCAG standard.
-
 ---
 
 ## Adaptable
 
-_Create content that can be presented in different ways without losing information or structure._
+Create content that can be presented in different ways without losing information or structure.
 
 ### Info and Relationships
+
+Information, structure, and relationships conveyed through presentation are available in text.
+
+*This guideline covers point 1.3.1 Info and Relationships - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -145,13 +146,11 @@ That way users of accessibility services can choose to navigate between headings
 
 - it is not clear which parts of the screen are contextually connected to each other
 
-#### Additional notes
-
-This guideline covers point 1.3.1 Info and Relationships - Level A of the WCAG standard.
-
 ---
 
 ### Meaningful sequence
+
+*This guideline covers point 1.3.2 Meaningful sequence - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -193,13 +192,11 @@ ViewCompat.setAccessibilityDelegate(button1, object : AccessibilityDelegateCompa
 
 - views displayed on the screen break consistency of navigation
 
-#### Additional notes
-
-This guideline covers point 1.3.2 Meaningful sequence - Level A of the WCAG standard.
-
 ---
 
 ### Sensory characteristics
+
+*This guideline covers point 1.3.3 Sensory characteristics - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -208,10 +205,6 @@ It is important that the content provided in your app is easily understandable t
 :no_entry_sign: **Failure criteria**
 
 - important difference between elements is stressed only with colors
-
-#### Additional notes
-
-This guideline covers point 1.3.3 Sensory characteristics - Level A of the WCAG standard.
 
 ---
 

--- a/docs/guidelines/platforms/android/guideline_robust_android.md
+++ b/docs/guidelines/platforms/android/guideline_robust_android.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
 
 # Robust guidelines for Android
 

--- a/docs/guidelines/platforms/android/guideline_robust_android.md
+++ b/docs/guidelines/platforms/android/guideline_robust_android.md
@@ -1,10 +1,12 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
+
 # Robust guidelines for Android
 
 Content must be robust enough that it can be interpreted by a wide variety of mobile devices including those which use accessibility features.
 
 ## Compatible
 
-_Maximize compatibility with current and future devices, taking into account the accessibility features that they might be using._
+Maximize compatibility with current and future devices, taking into account the accessibility features that they might be using.
 
 ### Parsing
 

--- a/docs/guidelines/platforms/android/guideline_understandable_android.md
+++ b/docs/guidelines/platforms/android/guideline_understandable_android.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
 
 # Understandable guidelines for Android
 

--- a/docs/guidelines/platforms/android/guideline_understandable_android.md
+++ b/docs/guidelines/platforms/android/guideline_understandable_android.md
@@ -1,10 +1,14 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
+
 # Understandable guidelines for Android
 
 ## Readable
 
-_Make text content readable and understandable._
+Make text content readable and understandable.
 
 ### Language of the App
+
+*This guideline covers point 3.1.1 Language of Page - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -22,15 +26,13 @@ If the application is server-driven and most of the content is depending on the 
 
 - the default language of the app is hardcoded and it is impossible to change it
 
-#### Additional notes
-
-This guideline covers point 3.1.1 Language of Page - Level A of the WCAG standard.
-
 ---
 
 ## Predictable
 
-_Make mobile apps appear and operate in predictable ways._
+Make mobile apps appear and operate in predictable ways.
+
+*This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.*
 
 ### On Focus & On Input
 
@@ -44,17 +46,15 @@ If the content that is displayed on the screen is designed and implemented follo
 
 - the content is not grouped based on context relationships and has no meaningful labels defined
 
-#### Additional notes
-
-This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.
-
 ---
 
 ## Input Assistance
 
-_Help users avoid and correct mistakes._
+Help users avoid and correct mistakes.
 
 ### Error identification
+
+*This technique covers point 3.3.1 Error Identification - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -70,13 +70,11 @@ On the other hand, if your app requires the implementation of custom components,
 
 - custom components do not support custom error handling 
 
-#### Additional notes
-
-This technique covers point 3.3.1 Error Identification - Level A of the WCAG standard.
-
 ---
 
 ### Labels or instruction
+
+*This technique covers point 3.3.2 Labels or Instructions - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -106,10 +104,6 @@ In the given example, services such as TalkBack will read - "EditBox for usernam
 :no_entry_sign: **Failure criteria**
 
 - not providing enough context for the views that expect user interaction
-
-#### Additional notes
-
-This technique covers point 3.3.2 Labels or Instructions - Level A of the WCAG standard.
 
 ---
 

--- a/docs/guidelines/platforms/flutter/guideline_operable_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_operable_flutter.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
 
 # Operable guidelines for Flutter
 
@@ -106,7 +106,7 @@ Apps should not contain elements that flash more than three times in one second 
 
 - Avoiding flashing content in general, if possible.
 
-- If using flashing content - keep the flash of an element running for a minimum of 333ms.
+- If using flashing content - keep the flash of an element running for a minimum of 333ms ([more than three per second](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)).
 
 - If the usage of an element that flashes more frequently is unavoidable - make sure that the flashing area is covering less than 25% within 10 degrees of a visual field.
 

--- a/docs/guidelines/platforms/flutter/guideline_operable_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_operable_flutter.md
@@ -1,8 +1,12 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
+
 # Operable guidelines for Flutter
 
-_User interface components and navigation must be operable._
+User interface components and navigation must be operable.
 
 ## Keyboard accessible
+
+*This guideline covers point 2.1.1 Keyboard and  2.4.3 Focus Order - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -45,11 +49,13 @@ FocusTraversalGroup(
 
 More about focus traversal at: https://docs.flutter.dev/development/ui/advanced/focus#controlling-what-gets-focus
 
-*This guideline covers point 2.1.1 Keyboard and  2.4.3 Focus Order - Level A of the WCAG standard.*
-
 ---
 
 ## Enough time
+
+Provide users enough time to read and use content.
+
+*This guideline covers point 2.2.1 Timing Adjustable - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -65,13 +71,13 @@ All users should have the ability to interact with the content displayed on the 
 
 - define time-limited actions in the app with no ability to extend that limit
 
-*This guideline covers point 2.2.1 Timing Adjustable - Level A of the WCAG standard.*
-
 ---
 
 ### Pause, Stop, Hide
 
 Moving, blinking, or scrolling, or auto-updating content in the app.
+
+*This guideline covers point 2.2.2 Pause, Stop Hide - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -83,16 +89,18 @@ Moving, blinking, or scrolling, or auto-updating content in the app.
 
 - Using an auto-updating or auto-scrolling view that can't be paused/stopped.
 
-*This guideline covers point 2.2.2 Pause, Stop Hide - Level A of the WCAG standard.*
-
 ---
 
 
 ## Seizures and Physical Reactions
 
+Do not design content in a way that is known to cause seizures or physical reactions.
+
 ### Three Flashed or Below Treshold
 
 Apps should not contain elements that flash more than three times in one second period.
+
+*This guideline covers point 2.3.1 - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -108,11 +116,13 @@ Apps should not contain elements that flash more than three times in one second 
 
 - Having a larger area of screen flashing more than three times per second
 
-*This guideline covers point 2.3.1 - Level A of the WCAG standard.*
-
 ---
 
 ### Bypass Blocks
+
+A skip mechanism is available to bypass blocks of content that are repated in the app.
+
+*This guideline covers point 2.4.1 Bypass Blocks - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -128,11 +138,13 @@ To accomplish this use `Semantics(container: true, label: 'Stories', child: ...)
 
 Not providing a way for user to quickly skip over sections with numerous items.
 
-*This guideline covers point 2.4.1 Bypass Blocks - Level A of the WCAG standard.*
-
 ---
 
 ### Page Titles
+
+Screens have a clear, descriptive, and possibly unique title that describes topic or purpose and is easily understood by all users.
+
+*This guideline covers point 2.4.2 Page Titled - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -145,11 +157,11 @@ If you're setting AppBar in `Scaffold(appBar: ...)` then the title will be read 
 - Leaving the title empty
 - Using a custom title view or custom navigation bar without ensuring it's readable by screen reader
 
-*This guideline covers point 2.4.2 Page Titled - Level A of the WCAG standard.*
-
 ---
 
 ### Link Purpose
+
+*This guideline covers point 2.4.4 Link Purpose (In Context) - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -164,8 +176,6 @@ Important piece here is that you should wrap the link with `Semantics(link: true
 - link is defined as unclear label or button and has no additional description provided
 
 - link is part of the longer text and implemented using ClickableSpan so TalkBack users are not aware of link existence
-
-*This guideline covers point 2.4.4 Link Purpose (In Context) - Level A of the WCAG standard.*
 
 ---
 

--- a/docs/guidelines/platforms/flutter/guideline_perceivable_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_perceivable_flutter.md
@@ -1,8 +1,15 @@
-# Operable
 
-_User interface components and navigation must be operable._
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
 
-## [Text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives) 
+# Operable guidelines for Flutter
+
+User interface components and navigation must be operable.
+
+## Text alternatives
+
+Provide text alternatives for any non-text content to be changed into other forms people need, such as large print, braille, speech, symbols, or more straightforward language.
+
+*This guideline covers point 1.1.1 Non-text Content - Level A of the WCAG standard.*
 
 ### Non-text content identification
 
@@ -24,14 +31,13 @@ Image(image: AssetImage('assets/settings.png'), semanticLabel: 'Open settings')
 
 - Do not provide semantics of elements that only exist for a decorative person. This will make navigation with screen readers harder.
 
-
-#### Additional notes
-
-This guideline covers point 1.1.1 Non-text Content - Level A of the WCAG standard.
-
 ---
 
-## [Time-based Media](https://www.w3.org/TR/WCAG21/#time-based-media)
+## Time-based Media
+
+Provide alternatives for time-based media.
+
+*This guideline covers point 1.2 Time-Based Media - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -45,15 +51,15 @@ If the app you are building includes media content such as video clips or audio 
 
 - all media is presented to the user without the possibility to change some of the controls (slow down, pause, volume up etc.)
 
-#### Additional notes
-
-This guideline covers point 1.2 Time-Based Media - Level A of the WCAG standard.
-
 ---
 
-## [Adaptable](https://www.w3.org/TR/WCAG21/#adaptable)
+## Adaptable
 
 ### Info and Relationships
+
+Information, structure, and relationships conveyed through presentation are available in text.
+
+*This guideline covers point 1.3.1 Info and Relationships - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -75,13 +81,11 @@ That way users of accessibility services can choose to navigate between headings
 
 - it is not clear which parts of the screen are contextually connected to each other
 
-#### Additional notes
-
-This guideline covers point 1.3.1 Info and Relationships - Level A of the WCAG standard.
-
 ---
 
 ### Meaningful sequence
+
+*This guideline covers point 1.3.2 Meaningful sequence - Level A of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
@@ -111,14 +115,13 @@ Row(
 );
 ```
 
-#### Additional notes
-
-This guideline covers point 1.3.2 Meaningful sequence - Level A of the WCAG standard.
-
 ---
 
 ### Sensory characteristics
 
+Instructions provided for understanding and operating content do not rely solely on sensory characteristics of components such as shape, color, size, visual location, orientation, or sound.
+
+*This guideline covers point 1.3.3 Sensory characteristics - Level A of the WCAG standard.*
 #### ✅ Success technique(s)
 
 To make our app entirely understandable to the users, we should not rely only on one characteristic to show the user elements on the screen. You can find different ways to satisfy this aspect in the text below.

--- a/docs/guidelines/platforms/flutter/guideline_perceivable_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_perceivable_flutter.md
@@ -1,5 +1,5 @@
 
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
 
 # Operable guidelines for Flutter
 

--- a/docs/guidelines/platforms/flutter/guideline_robust_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_robust_flutter.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
 
 # Robust guidelines for Flutter
 

--- a/docs/guidelines/platforms/flutter/guideline_robust_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_robust_flutter.md
@@ -1,0 +1,66 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
+
+# Robust guidelines for Flutter
+
+## Compatible
+
+### Name, Role, Value
+
+*This guideline covers point 4.1.2 Name, Role, Value - Level A of the WCAG standard.*
+
+#### ✅ Success technique(s)
+
+UI components, like form elements, can have beside accessibility label their role and value. If you are using standard widgets
+from Flutter framework these roles and values will be handled for you.
+
+If you are building something custom, like painting your own RenderObject, then you need to be aware of it.
+
+Some examples are:
+
+- Is the widget a text field:
+```dart
+Semantics(label: 'Add', hint: 'Adds an entry in the list',  ...)
+```
+
+- Is the widget a text field:
+```dart
+Semantics(textField: true, ...)
+```
+
+- Is the widget is obscured text field:
+```dart
+Semantics(textField: true, obscured: true, ...)
+```
+
+- Is the widget a checkbox, pass the value:
+```dart
+Semantics(checked: true or false, ...)
+```
+
+- Mixed state, Half-checked or tri-state checkbox:
+```dart
+Semantics(mixed: true, ...)
+```
+
+- Widget can be selected
+```dart
+Semantics(selected: true or false, ...)
+```
+
+- Is the widget a slider control:
+```dart
+Semantics(slider: true, ...)
+```
+
+And several other fields.
+
+
+#### 🚫 Failures
+
+Implementing custom controls which are unfamiliar to the users and don't carry the necessary accessibility identifying information as defined in this guideline.
+
+Changing the value or role of a user interface element without adjusting it's identifier programmatically.
+
+⎯
+
+[← Robust principle](../../principles/robust_principle.md "Robust principle")

--- a/docs/guidelines/platforms/flutter/guideline_understandable_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_understandable_flutter.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
 
 # Understandable guidelines for Flutter
 

--- a/docs/guidelines/platforms/flutter/guideline_understandable_flutter.md
+++ b/docs/guidelines/platforms/flutter/guideline_understandable_flutter.md
@@ -1,3 +1,5 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
+
 # Understandable guidelines for Flutter
 
 ## Readable
@@ -8,8 +10,7 @@ Make text content readable and understandable.
 
 The default human language of an App can be programmatically determined.
 
-*This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.*
-
+*This guideline covers point 3.1.1 Language of Page - Level A of the WCAG standard.*
 #### ✅ Success technique(s)
 
 If the app supports multiple languages, we should also care that accessibility labels are localized as well.
@@ -29,12 +30,13 @@ Hard-coding a language code and labels inside an app should be avoided.
 
 Also, every app should be developed as a localizable app, even if it seems like it makes no sense at the start, or all of the intended audience speak a single language, it can still happen that some users will not be able to use that language and there is always a possibility that your app will scale to different language regions or that parts of your code will be reused on different projects which _do_ use localization.
 
-*This guideline covers point 3.1.1 Language of Page - Level A of the WCAG standard.*
-
 ## Predictable
+
+Make mobile apps appear and operate in predictable ways.
 
 ### On Focus & On Input
 
+*This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.*
 #### ✅ Success technique(s)
 
 Users need to be able to consume content without any sudden interruptions and/or changes of context. Receiving focus on or interacting with any component should not initiate a change of context unless previously announced. By change of context we mean major changes in the content of the screen.

--- a/docs/guidelines/platforms/ios/guideline_operable_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_operable_ios.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
 
 # Operable
 

--- a/docs/guidelines/platforms/ios/guideline_operable_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_operable_ios.md
@@ -1,14 +1,18 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Operable principle](../../principles/operable_principle.md "Operable principle")
+
 # Operable
 
 User interface components and navigation must be operable.
 
 ## Enough Time
 
-_Provide users enough time to read and use content._
+Provide users enough time to read and use content.
 
 ### Timing Adjustable
 
 For each time limit set by the content, user can turn off, adjust, or extend it.
+
+*This guideline covers point 2.2.1 Timing Adjustable - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -25,15 +29,13 @@ For each time limit set by the content, user can turn off, adjust, or extend it.
 - Logging user out of their session with no prior warning.
 - Not providing enough time or time extensions to react on an incoming action in the app.
 
-#### Additional notes
-
-This guideline covers point 2.2.1 Timing Adjustable - Level A of the WCAG standard.
-
 ---
 
 ### Pause, Stop, Hide
 
 Moving, blinking, or scrolling, or auto-updating content in the app.
+
+*This guideline covers point 2.2.2 Pause, Stop Hide - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -45,20 +47,17 @@ Moving, blinking, or scrolling, or auto-updating content in the app.
 
 - Using an auto-updating or auto-scrolling view that can't be paused/stopped.
 
-#### Additional notes
-
-This guideline covers point 2.2.2 Pause, Stop Hide - Level A of the WCAG standard.
-
 ---
-
 
 ## Seizures and Physical Reactions
 
-_Do not design content in a way that is known to cause seizures or physical reactions._
+Do not design content in a way that is known to cause seizures or physical reactions.
 
 ### Three Flashed or Below Treshold
 
 Apps should not contain any element that flashes more than three times in any one second period.
+
+*This guideline covers point 2.3.1 - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -71,10 +70,6 @@ Apps should not contain any element that flashes more than three times in any on
 - Using rapidly flashing elements to catch user's attention.
 - Having a larger area of screen flashing more than three times per second.
 
-#### Additional notes
-
-This guideline covers point 2.3.1 - Level A of the WCAG standard.
-
 ---
 
 ## Navigable
@@ -84,6 +79,8 @@ _Provide ways to help users navigate, find content, and determine where they are
 ### Bypass Blocks
 
 A skip mechanism is available to bypass blocks of content that are repated in the app.
+
+*This guideline covers point 2.4.1 Bypass Blocks - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -105,16 +102,13 @@ A skip mechanism is available to bypass blocks of content that are repated in th
 
 Not providing a way for user to quickly skip over sections with numerous items.
 
-#### Additional notes
-
-This guideline covers point 2.4.1 Bypass Blocks - Level A of the WCAG standard.
-
 ---
-
 
 ### Page Titled
 
 Screens have a clear, descriptive, and possibly unique title that describes topic or purpose and is easily understood by all users.
+
+*This guideline covers point 2.4.2 Page Titled - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -151,16 +145,14 @@ Screens have a clear, descriptive, and possibly unique title that describes topi
   - file names like "report.pdf" or "DSC_0123.jpeg"
   - placeholder text like "Enter title..." or "Search..."
 
-#### Additional notes
-
-This guideline covers point 2.4.2 Page Titled - Level A of the WCAG standard.
-
 ---
 
 
 ### Focus Order
 
 VoiceOver: Ensure that information is read in an order consistent with the meaning and content.
+
+*This guideline covers point 2.4.3 Focus Order - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -204,16 +196,14 @@ Keep in mind: when placed outside a stack view, elements positioned closer to th
         return true
     }
 ```
-#### Additional notes
-
-This guideline covers point 2.4.3 Focus Order - Level A of the WCAG standard.
 
 ---
-
 
 ### Action Purpose
 
 Purpose of a button or link action is clear and easily understandable by all users
+
+*This guideline covers point 2.4.4 Link Purpose (In Context) - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -261,10 +251,6 @@ Purpose of a button or link action is clear and easily understandable by all use
 *"Are you sure you want to cancel your booking? This action is ireversible" 
 ▸ OK  ▸ Cancel*
 - Button titles with unclear result like "Ready to publish?"
-
-#### Additional notes
-
-This guideline covers point 2.4.4 Link Purpose (In Context) - Level A of the WCAG standard.
 
 ⎯
 

--- a/docs/guidelines/platforms/ios/guideline_perceivable_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_perceivable_ios.md
@@ -1,3 +1,4 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
 # Perceivable guidelines for iOS
 
 Information and user interface components must be presentable to users in ways they can perceive.
@@ -26,6 +27,7 @@ When talking about group components or containers on the screen, it is an excell
 
 Another important thing about labeling elements is the context. Some static elements like images provide a context, like an image with the alert or check element. In that case, instead of setting the label as a "check icon", it can be defined as "successful submission" to give the user a bit more information.
 
+*This guideline with provided techniques covers the 1.1.1 Non-text Content - Level A of the WCAG standard.*
 #### Using accessibility value and hint
 
 Alongside the accessibility label, iOS as a platform supports the definition of an accessibility value and accessibility hint. If some elements can have and should provide specific values, accessibility value can be used alongside the accessibility label. And when talking about element interactivity, accessibility hint can be used as well - but be aware that the user can disable accessibility hints.
@@ -38,10 +40,6 @@ addButton.accessibilityHint = "Adds a new task"
 
 Sometimes it is not a good idea to give accessibility labels to all screen elements. Some elements may only be defined as decorative elements that do not affect the screen functionality (e.g. small elements like images used for screen decoration). In that case, labeling elements like that may confuse the user.
 
-#### Additional notes
-
-This guideline with provided techniques covers the 1.1.1 Non-text Content - Level A of the WCAG standard.
-
 ## Time-based Media
 
 Provide alternatives for time-based media.
@@ -50,6 +48,7 @@ Provide alternatives for time-based media.
 
 Due to some disabilities, some users may not be able to hear the content of the media provided by the application. An example of that can be a prerecorded audio or video track. In some cases it is necessary to add support for some accessibility features to make this content accessible to all users.
 
+*This guideline with provided techniques covers the 1.2.1 Audio-only and Video-only (Prerecorded) - Level A and 1.2.2 Captions (Prerecorded) - Level A of the WCAG standard.*
 #### ✅ Success technique(s)
 
 ##### Using AVPlayer with captions
@@ -100,10 +99,6 @@ final class VideoViewController: UIViewController {
 ##### Using transcripts
 
 Supplying transcripts is another way of providing users with information in prerecorded audio or video. If defined correctly, text on the screen can be read by VoiceOver for people with visibility issues, while people with hearing issues can read the transcript. This way, both scenarios are satisfied without a need to provide captions.
-
-#### Additional notes
-
-This guideline with provided techniques covers the 1.2.1 Audio-only and Video-only (Prerecorded) - Level A and 1.2.2 Captions (Prerecorded) - Level A of the WCAG standard.
 
 ## Adaptable
 

--- a/docs/guidelines/platforms/ios/guideline_perceivable_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_perceivable_ios.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
+ [🔼 Accessibility principles and examples](a../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")
 # Perceivable guidelines for iOS
 
 Information and user interface components must be presentable to users in ways they can perceive.

--- a/docs/guidelines/platforms/ios/guideline_robust_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_robust_ios.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
 
 # Robust guidelines for iOS
 

--- a/docs/guidelines/platforms/ios/guideline_robust_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_robust_ios.md
@@ -1,3 +1,5 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️  Robust principle](../../principles/robust_principle.md "Robust principle")
+
 # Robust guidelines for iOS
 
 Content must be robust enough that it can be interpreted by a wide variety of mobile devices including those which use accessibility features.
@@ -9,6 +11,8 @@ Maximize compatibility with current and future devices, taking into account the 
 ### Parsing
 
 All user-visible content be grouped logically and assigned identifiers appropriately.
+
+*This guideline covers point 4.1.1 Parsing - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -47,13 +51,11 @@ Duplicate identifiers used for elements which are essentially different in their
 
 Elements are not grouped or are badly organized on the screen which prevents accessibility features from quickly and efficiently moving through them.
 
-#### Additional notes
-
-This guideline covers point 4.1.1 Parsing - Level A of the WCAG standard.
-
 ### Name, Role, Value
 
 User interface elements should be clearly defined by their name ([accessibility label](https://developer.apple.com/documentation/objectivec/nsobject/1615181-accessibilitylabel) & [accessibility hint](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint)), the role that they have (accessibility identifier), and the value they carry([accesibility value](https://developer.apple.com/documentation/objectivec/nsobject/1615117-accessibilityvalue)). The app should be able to notify the user if any of these parameters change programmatically without user input (or the changes should be reflected in the element's accessibility attributes), so that the user remains aware of what this element does at all times.
+
+*This guideline covers point 4.1.2 Name, Role, Value - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -78,10 +80,6 @@ Not providing accessibility identifiers for user interface elements.
 Implementing custom controls which are unfamiliar to the users and don't carry the necessary accessibility identifying information as defined in this guideline.
 
 Changing the value or role of a user interface element without adjusting it's identifier programmatically.
-
-#### Additional notes
-
-This guideline covers point 4.1.2 Name, Role, Value - Level A of the WCAG standard.
 
 ⎯
 

--- a/docs/guidelines/platforms/ios/guideline_understandable_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_understandable_ios.md
@@ -1,4 +1,4 @@
- [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
+ [🔼 Accessibility principles and examples](../../principles/accessibility_principles_and_examples.md  "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
  
 # Understandable guidelines for iOS
 

--- a/docs/guidelines/platforms/ios/guideline_understandable_ios.md
+++ b/docs/guidelines/platforms/ios/guideline_understandable_ios.md
@@ -1,3 +1,5 @@
+ [🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Understandable principle](../../principles/understandable_principle.md "Understandable principle")
+ 
 # Understandable guidelines for iOS
 
 Information and the operation of the user interface must be understandable.
@@ -9,6 +11,8 @@ Make text content readable and understandable.
 ### Language of Page
 
 The default human language of an App can be programmatically determined.
+
+*This guideline covers point 3.1.1 Language of Page - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -37,10 +41,6 @@ Bundle.setLanguage(language)
 
 Also, every app should be developed as a localizable app, even if it seems like it makes no sense at the start, or all of the intended audience speak a single language, it can still happen that some users will not be able to use that language and there is always a possibility that your app will scale to different language regions or that parts of your code will be reused on different projects which _do_ use localization.
 
-#### Additional notes
-
-This guideline covers point 3.1.1 Language of Page - Level A of the WCAG standard.
-
 ## Predictable
 
 Make mobile apps appear and operate in predictable ways.
@@ -48,6 +48,8 @@ Make mobile apps appear and operate in predictable ways.
 ### On Focus & On Input
 
 Receiving focus on or interacting with any component should not initiate a change of context unless previously announced.
+
+*This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -99,10 +101,6 @@ func textFieldDidBeginEditing(_ textField: UITextField) {
 }
 ```
 
-#### Additional notes
-
-This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.
-
 ## Input Assistance
 
 Help users avoid and correct mistakes when interacting with the app.
@@ -110,6 +108,8 @@ Help users avoid and correct mistakes when interacting with the app.
 ### Error Identification
 
 If an input error is automatically detected, the item that is in error is identified and the error is clearly described to the user in text.
+
+*This technique covers point 3.3.1 Error Identification - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -148,13 +148,11 @@ generator.notificationOccurred(.success)
 
 Preventing some action or flow from continuing because an error was detected but not communicating to the user how/when the error was made and/or what needs to be done to correct it.
 
-#### Additional notes
-
-This technique covers point 3.3.1 Error Identification - Level A of the WCAG standard.
-
 ### Labels or Instructions
 
 Labels or instructions are provided when content requires user input.
+
+*This technique covers point 3.3.2 Labels or Instructions - Level A of the WCAG standard.*
 
 #### ✅ Success technique(s)
 
@@ -178,10 +176,6 @@ usernameHolderView.shouldGroupAccessibilityChildren = true
 #### 🚫 Failures
 
 User enters some data into a user interface element without knowing what the end result is and/or triggering an unannounced change of context in the process.
-
-#### Additional notes
-
-This technique covers point 3.3.2 Labels or Instructions - Level A of the WCAG standard.
 
 ⎯
 

--- a/docs/guidelines/principles/operable_principle.md
+++ b/docs/guidelines/principles/operable_principle.md
@@ -30,6 +30,7 @@ In this chapter you can find principle-related guidelines and examples for mobil
 
 * [Android](../platforms/android/guideline_operable_android.md "Operable guidelines for Android")
 * [iOS](../platforms/ios/guideline_operable_ios.md "Operable guidelines for iOS")
+* [Flutter](../platforms/flutter/guideline_operable_ios.md "Operable guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/operable_principle.md
+++ b/docs/guidelines/principles/operable_principle.md
@@ -30,7 +30,7 @@ In this chapter you can find principle-related guidelines and examples for mobil
 
 * [Android](../platforms/android/guideline_operable_android.md "Operable guidelines for Android")
 * [iOS](../platforms/ios/guideline_operable_ios.md "Operable guidelines for iOS")
-* [Flutter](../platforms/flutter/guideline_operable_ios.md "Operable guidelines for Flutter")
+* [Flutter](../platforms/flutter/guideline_operable_flutter.md "Operable guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/perceivable_principle.md
+++ b/docs/guidelines/principles/perceivable_principle.md
@@ -4,8 +4,9 @@
 
 In this chapter you can find principle-related guidelines and examples for mobile platforms;
 
-* [Android](../platforms/android/guideline_perceivable_android.md "Perceivable guidelines for Android")
+* [Android](../platforms/android/guideline_percievable_android.md "Perceivable guidelines for Android")
 * [iOS](../platforms/ios/guideline_perceivable_ios.md "Perceivable guidelines for iOS")
+* [Flutter](../platforms/flutter/guideline_perceivable_ios.md "Perceivable guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/perceivable_principle.md
+++ b/docs/guidelines/principles/perceivable_principle.md
@@ -6,7 +6,7 @@ In this chapter you can find principle-related guidelines and examples for mobil
 
 * [Android](../platforms/android/guideline_percievable_android.md "Perceivable guidelines for Android")
 * [iOS](../platforms/ios/guideline_perceivable_ios.md "Perceivable guidelines for iOS")
-* [Flutter](../platforms/flutter/guideline_perceivable_ios.md "Perceivable guidelines for Flutter")
+* [Flutter](../platforms/flutter/guideline_perceivable_flutter.md "Perceivable guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/robust_principle.md
+++ b/docs/guidelines/principles/robust_principle.md
@@ -16,6 +16,7 @@ In this chapter you can find principle-related guidelines and examples for mobil
 
 * [Android](../platforms/android/guideline_robust_android.md "Robust guidelines for Android")
 * [iOS](../platforms/ios/guideline_robust_ios.md "Robust guidelines for iOS")
+* [Flutter](../platforms/flutter/guideline_robust_ios.md "Robust guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/robust_principle.md
+++ b/docs/guidelines/principles/robust_principle.md
@@ -16,7 +16,7 @@ In this chapter you can find principle-related guidelines and examples for mobil
 
 * [Android](../platforms/android/guideline_robust_android.md "Robust guidelines for Android")
 * [iOS](../platforms/ios/guideline_robust_ios.md "Robust guidelines for iOS")
-* [Flutter](../platforms/flutter/guideline_robust_ios.md "Robust guidelines for Flutter")
+* [Flutter](../platforms/flutter/guideline_robust_flutter.md "Robust guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/understandable_principle.md
+++ b/docs/guidelines/principles/understandable_principle.md
@@ -46,7 +46,7 @@ In this chapter, you can find principle-related guidelines and examples for mobi
 
 * [Android](../platforms/android/guideline_robust_android.md "Robust guidelines for Android")
 * [iOS](../platforms/ios/guideline_understandable_ios.md "Understandable guidelines for iOS")
-* [Flutter](../platforms/flutter/guideline_understandable_ios.md "Understandable guidelines for Flutter")
+* [Flutter](../platforms/flutter/guideline_understandable_flutter.md "Understandable guidelines for Flutter")
 
 ⎯
 

--- a/docs/guidelines/principles/understandable_principle.md
+++ b/docs/guidelines/principles/understandable_principle.md
@@ -46,6 +46,7 @@ In this chapter, you can find principle-related guidelines and examples for mobi
 
 * [Android](../platforms/android/guideline_robust_android.md "Robust guidelines for Android")
 * [iOS](../platforms/ios/guideline_understandable_ios.md "Understandable guidelines for iOS")
+* [Flutter](../platforms/flutter/guideline_understandable_ios.md "Understandable guidelines for Flutter")
 
 ⎯
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -67,16 +67,14 @@ In this document, usage of component identifiers like `accessibilityIdentifier` 
 
 - **Android**
 
-For manual testing, the usual way in native Android is testing using Accesibility scanner. Unfortunatelly that doesn't work with Flutter yet ([see open issue](https://github.com/flutter/flutter/issues/39531)).
+For manual testing, the usual way in native Android is testing using Accessibility Scanner. Unfortunatelly that doesn't work with Flutter yet ([see open issue](https://github.com/flutter/flutter/issues/39531)).
 You can use TalkBack, but that's mainly inteded for real users that needs accessibility features. It's good so you know how everything works for user, but it's a bit complex and slow to use for testing.
-
-For automated testing, maily it's about widget tests and inspecting that correct semantics is applied.
 
 - **iOS**
 
+For manual testing, you can use XCode Accessibility Inspector. It's similar tool as Android's Accesibility Scanner. Advanced tool that users use is VoiceOver which is an equivalent of Android's TalkBack.
 
-
-
+For automated testing, main approach is writing widget tests and inspecting that correct semantics is applied.
 
 ⎯
 


### PR DESCRIPTION
- Added navigation to Flutter pages (that I was missing)
- Added "navigation bar" to all platform guidelines, looks like this

[🔼 Accessibility principles and examples](accessibility_principles_and_examples.md "Accessibility principles and examples") | [⬅️ Perceivable principle](../../principles/perceivable_principle.md "Perceivable principle")


- Fixed Android navigation

There was one bug

- Changed those WCAG links from Additional notes header

As we agreed this one-sentence section didn't deserve its own big header.