### PR TITLE
Android guidelines -  Support for pre-populated forms

### DIFF
--- a/docs/guidelines/platforms/android/guideline_understandable_android.md
+++ b/docs/guidelines/platforms/android/guideline_understandable_android.md
@@ -140,6 +140,28 @@ TextField(
 
 - Not providing enough context for the views / composables that expect user interaction.
 
+### Redundant Entry (WCAG 3.3.7 - Level A)
+
+Ensure that multi-step processes are user-friendly by not requesting the same information multiple times in a session, as this can be challenging for those with cognitive disabilities. This approach enhances accessibility by reducing memory load and simplifying tasks.
+
+> This technique covers point *3.3.7 Redundant Entry - Level A of the WCAG standard.*
+
+#### ✅ Success technique(s)
+
+Information previously entered by or provided to the user that is required to be entered again in the same process is either:
+
+- auto-populated, or
+- available for the user to select.
+
+Techniques mentioned above does not apply to the following cases:
+
+- when re-entering the information is essential
+  - Example: A banking app asks users to re-enter their password before confirming a money transfer.
+- when the information is required to ensure the security of the content
+  - Example: A login screen requires users to re-enter their password after a period of inactivity.
+- when previously entered information is no longer valid
+  - Example: After changing their email address, a user must re-enter the new email to confirm it.
+
 ---
 
 #### Sources

--- a/docs/guidelines/platforms/android/guideline_understandable_android.md
+++ b/docs/guidelines/platforms/android/guideline_understandable_android.md
@@ -162,6 +162,10 @@ Techniques mentioned above does not apply to the following cases:
 - when previously entered information is no longer valid
   - Example: After changing their email address, a user must re-enter the new email to confirm it.
 
+#### 🚫 Failures
+  
+Failures are not defined by the WCAG at the time of writing this.
+
 ---
 
 #### Sources

--- a/docs/guidelines/principles/guideline_checklist.md
+++ b/docs/guidelines/principles/guideline_checklist.md
@@ -60,7 +60,7 @@ Guidelines mentioned in this section are related to the screen reader and intera
 - [ ] 3.3.2 Labels or instructions (A) - [Android](../platforms/android/guideline_understandable_android.md#labels-or-instructions-wcag-332---level-a) | [iOS](../platforms/ios/guideline_understandable_ios.md#labels-or-instructions-wcag-332---level-a) | Flutter
 - [ ] 3.3.3 Error suggestion (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#error-suggestion-wcag-333---level-aa) | Flutter
 - [ ] 3.3.4 Error prevention (legal, financial, data) - (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#error-prevention-legal-financial-data-wcag-334---level-aa) | Flutter
-- [ ] 3.3.7 Redundant entry (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#redundant-entry-wcag-337---level-a) | Flutter
+- [ ] 3.3.7 Redundant entry (AA) - [Android](../platforms/android/guideline_understandable_android.md#redundant-entry-wcag-337---level-a) | [iOS](../platforms/ios/guideline_understandable_ios.md#redundant-entry-wcag-337---level-a) | Flutter
 - [ ] 4.1.2 Name, role, value (A) - [Android](../platforms/android/guideline_robust_android.md#name-role-value-wcag-412---level-a) | [iOS](../platforms/ios/guideline_robust_ios.md#name-role-value-wcag-412---level-a) | Flutter
 - [ ] 4.1.3 Status messages (AA) - [Android](../platforms/android/guideline_robust_android.md#status-messages-wcag-413---level-aa) | [iOS](../platforms/ios/guideline_robust_ios.md#status-messages-wcag-413---level-aa) | Flutter
 


### PR DESCRIPTION
Added guidelines for:
- https://github.com/infinum/accessibility-mobile-standards/issues/43

#### Note ⚠️  
The 3.3.7 doesn't have `Failures` defined because they're not defined in the WCAG requirements either. Since the guideline is quite abstract, I've reused the text from the WCAG which explains it well, and enhanced it with some examples to make it more understandable