### PR TITLE
Android guidelines - Navigation through components and screens - Level A

### DIFF
--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -163,7 +163,7 @@ The first step in satisfying the criteria is having a design that breaks content
 Once that is done, it will get picked up by TalkBack and the user will be able to skip parts of content by navigating through headings. This should be automatically satisfied by following the [Heading and Labels guideline](guideline_operable_android.md#heading-and-labels-wcag-246---level-aa).
 
 #### Controls
-TalkBack can recognize that something is a control based on the element's role (button, toggle, edit text etc.). Native controls will always be recognized automatically. For custom components, make sure to set a proper role as described in the [Info and relationships guideline](guideline_percievable_android.md#info-and-relationships-wcag-131---level-a).
+TalkBack can recognize that something is a control based on the element's role (button, toggle, edit text etc.). Native controls will always be recognized automatically. For custom components, make sure to set a proper role as described in the [Name, Role, Value chapter](guideline_robust_android.md#name-role-value-wcag-412---level-a).
 
 #### Links
 This criteria should be satisfied by following the recommendations from [Link purpose guideline](guideline_operable_android.md#link-purpose).

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -150,11 +150,11 @@ Provide ways to help users navigate, find content, and determine where they are.
 
 The app should be implemented so that it is possible to relatively easily skip the content that is repeated on the screen or the content that is irrelevant to the user.
 
+In addition to the basic left/right swipe navigation through elements, TalkBack offers navigation by element types (headings, controls and links) and fine-grained navigation through text (by paragraphs, lines, words and characters) which is controlled with up/down swipes, as explained in the [Reading controls chapter](https://support.google.com/accessibility/android/answer/6007066?hl=en) of Google's TalkBack support page. These alternate modes of navigation are the main tool used for bypassing blocks, so it is important to make sure they all work as intended. Fortunately, most of them work well with native components, but some require additional effort.
+
 ✅ **Success criteria**
 
 The first step in satisfying the criteria is having a design that breaks content into smaller pieces and provides us with "anchor points" that can be used to skip chunks of content (for example, splitting long text into paragraphs, or grouping form fields into sections with headings). After that, these anchor points need to be properly categorized (as headings, controls, etc.) in order to become visible to assistive services and used for navigation.
-
-In addition to the basic left/right swipe navigation through elements, TalkBack offers navigation by element types (headings, controls and links) and fine-grained navigation through text (by paragraphs, lines, words and characters) which is controlled with up/down swipes, as explained in the [Reading controls chapter](https://support.google.com/accessibility/android/answer/6007066?hl=en) of Google's TalkBack support page. These alternate modes of navigation are the main tool used for bypassing blocks, so it is important to make sure they all work as intended. Fortunately, most of them work well with native components, but some require additional effort.
 
 #### Headings within text
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -198,17 +198,17 @@ If the title is defined using a toolbar with custom behavior or another custom v
 
 ---
 
-### Focus Order
+### Focus Order (WCAG 2.4.3 - Level A)
 
-*This guideline covers point 2.4.3 Focus Order - Level A of the WCAG standard.*
+Ensure that information is read in an order consistent with the meaning and content.
 
-:white_check_mark: **Success criteria**
+✅ **Success criteria**
 
 Order of the components that are displayed on the screen should have a logical traversal order. This is very important for people using accessibility services (such as TalkBack) to get a clearer picture of the content and possible actions on the current screen that is navigated through.
 
-Defining the content of the screen in the meaningful sequence described in the [Perceivable guidelines](https://github.com/infinum/accessibility-mobile-standards/blob/master/docs/guidelines/platforms/android/guideline_percievable_android.md) automatically results in appropriate traversal order when navigating through the screen.
+Defining the content of the screen as the described in the [Meaningful sequence guideline](guideline_percievable_android.md#meaningful-sequence-wcag-132---level-a) automatically results in appropriate traversal order when navigating through the screen.
 
-:no_entry_sign: **Failure criteria**
+🚫 **Failure criteria**
 
 - Views displayed on the screen break consistency of the navigation.
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -146,63 +146,37 @@ Apps should not contain elements that flash more than three times in one second.
 
 Provide ways to help users navigate, find content, and determine where they are.
 
-### Bypass Blocks
-
-*This guideline covers points 2.4.1 Bypass Blocks - Level A of the WCAG standard.*
-
-:white_check_mark: **Success criteria**
+### Bypass Blocks (WCAG 2.4.1 - Level A)
 
 The app should be implemented so that it is possible to relatively easily skip the content that is repeated on the screen or the content that is irrelevant to the user.
 
-This feature is also based on a good implementation of grouping the views displayed in the app as described in [Perceivable guidelines](https://github.com/infinum/accessibility-mobile-standards/blob/master/docs/guidelines/platforms/android/guideline_percievable_android.md).
+✅ **Success criteria**
 
-For example, accessibility services users should be able to skip the whole RecyclerView list if the content is irrelevant to them without going through each item in the list.
+The first step in satisfying the criteria is having a design that breaks content into smaller pieces and provides us with "anchor points" that can be used to skip chunks of content (for example, splitting long text into paragraphs, or grouping form fields into sections with headings). After that, these anchor points need to be properly categorized (as headings, controls, etc.) in order to become visible to assistive services and used for navigation.
 
-- Headings within text
+In addition to the basic left/right swipe navigation through elements, TalkBack offers navigation by element types (headings, controls and links) and fine-grained navigation through text (by paragraphs, lines, words and characters) which is controlled with up/down swipes, as explained in the [Reading controls chapter](https://support.google.com/accessibility/android/answer/6007066?hl=en) of Google's TalkBack support page. These alternate modes of navigation are the main tool used for bypassing blocks, so it is important to make sure they all work as intended. Fortunately, most of them work well with native components, but some require additional effort.
 
-It is also possible to use _headings_ to summarize groups of text that appear on the screen. For apps with minSdk >= 28, you can set `android:accessibilityHeading` to `true` for a view to being treated as a heading.
+#### Headings within text
 
-That way, users of accessibility services, after setting the _navigation mode_ to _Headers_, can choose to navigate between headings instead of between paragraphs or between words which can improve the navigation experience.
+⚠️ There is no way for an element to be recognized as a heading automatically, so it must always be marked as a heading manually.
 
-_Note 1. Navigation mode can be chosen by swiping **up** and **down** when using **TalkBack**. Once Headers is chosen as a Navigation option, the user can navigate through **headers** by swiping right and left instead of navigating through single items.._
+Once that is done, it will get picked up by TalkBack and the user will be able to skip parts of content by navigating through headings. This should be automatically satisfied by following the [Heading and Labels guideline](guideline_operable_android.md#heading-and-labels-wcag-246---level-aa).
 
-```
-<TextView
-    android:id="@+id/personalData" ...
-    android:text="@string/personal_data_heading"
-    android:accessibilityHeading="true"/>
+#### Controls
+TalkBack can recognize that something is a control based on the element's role (button, toggle, edit text etc.). Native controls will always be recognized automatically. For custom components, make sure to set a proper role as described in the [Info and relationships guideline](guideline_percievable_android.md#info-and-relationships-wcag-131---level-a).
 
-<EditText
-    android:id="@+id/nameEntry" ... />
+#### Links
+This criteria should be satisfied by following the recommendations from [Link purpose guideline](guideline_operable_android.md#link-purpose).
 
-<EditText
-    android:id="@+id/surnameEntry" ... />
+#### Skippable groups
 
-<TextView
-    android:id="@+id/workplaceData" ...
-    android:text="@string/personal_data_heading"
-    android:accessibilityHeading="true"/>
+In addition to the above, a section of a screen containing numerous items should have related items grouped, so that they are easily skippable and do not require multiple swipes to go over. This feature is based on a good implementation of grouping as described in [Info and relationships - Element relationships guideline](guideline_percievable_android.md#element-relationships).
 
-<EditText
-    android:id="@+id/addressEntry" ... />
-```
-
-For apps with minSdk < 28, headings can be defined programmatically using ViewCompat.
-
-An example is given down below:
-
-```
-ViewCompat.setAccessibilityDelegate(personalData, object : AccessibilityDelegateCompat() {
-    override fun onInitializeAccessibilityNodeInfo(host: View?, info: AccessibilityNodeInfoCompat?) {
-        super.onInitializeAccessibilityNodeInfo(host, info)
-        info?.isHeading = true
-    }
-})
-```
-
-:no_entry_sign: **Failure criteria**
+🚫 **Failure criteria**
 
 - The user of accessibility services has to navigate through all the items displayed on the screen with no possibility to fasten the navigation process.
+    - No elements set as headings to separate bigger parts of text or groups in general.
+    - Controls not being recognized as such. This can happen when, for example, using `TextView` instead of a `Button` or `ImageView` instead of a `Checkbox` or a `Switch` without any accessibility info modifications.
 
 ---
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -206,7 +206,7 @@ Ensure that information is read in an order consistent with the meaning and cont
 
 Order of the components that are displayed on the screen should have a logical traversal order. This is very important for people using accessibility services (such as TalkBack) to get a clearer picture of the content and possible actions on the current screen that is navigated through.
 
-Defining the content of the screen as the described in the [Meaningful sequence guideline](guideline_percievable_android.md#meaningful-sequence-wcag-132---level-a) automatically results in appropriate traversal order when navigating through the screen.
+Defining the content of the screen as described in the [Meaningful sequence guideline](guideline_percievable_android.md#meaningful-sequence-wcag-132---level-a) automatically results in appropriate traversal order when navigating through the screen.
 
 🚫 **Failure criteria**
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -179,36 +179,7 @@ Every accessible element on the screen should hold information about itself and 
 
 The most important technique for achieving this criteria is properly labeling all of the elements on the screen, i.e. giving them a proper name and a role (heading, button, switch, edit text, etc.). In that way, no important information is lost when the user relies only on the auditory information read out by TalkBack and it is much easier to understand the purpose of an element on the screen.
 
-**Names**
-
-Use `contentDescription` to set a proper name for an element, as described in the [Non-text content identification chapter](guideline_percievable_android.md#non-text-content-identification-wcag-111---level-a). Names can also be set on a group or a container to give more context to the user, as explained below.
-
-
-**Roles**
-
-In View-based system, the best approach is to use (or inherit) native components, such as `Button`, `Checkbox`, `Switch`, `EditText` and so on, as they come with proper roles by default. If that is for some reason not possible, there is a way to make it appear as one of the native controls to accessibility services, by setting the `className` of the accessibility node info:
-
-```kotlin
-ViewCompat.setAccessibilityDelegate(binding.continueButton, object : AccessibilityDelegateCompat() {
-    override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
-        super.onInitializeAccessibilityNodeInfo(host, info)
-        info.className = Button::class.java.name
-    }
-})
-```
-
-When that is not enough, it is also possible to set a custom role string through `info.roleDescription` in the same way, but the description should not stray too far away from the already existing native components, as the user might not recognize them.
-
-In Compose, the same applies --- native controls will work automatically, but in case of custom components, a role can be set through the `semantics` block:
-
-```kotlin
-MyCustomButton(
-    onClick = ...,
-    modifier = Modifier.semantics { role = Role.Button }
-)
-```
-
-The complete list of existing roles is available in the [developer documentation](https://developer.android.com/reference/kotlin/androidx/compose/ui/semantics/Role).
+The techniques for adding names and roles to elements can be found in the [Name, Role, Value chapter](guideline_robust_android.md#name-role-value-wcag-412---level-a).
 
 🚫 **Failure criteria**
 - The purpose of an element on the screen is conveyed only through visual cues, and completely lost when using assistive technologies.

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -195,7 +195,7 @@ Many UI components should work together to create a context for the user. For ex
 
 When there are multiple elements that are connected, this connection needs to be clear when using assistive technologies. For example, in the case of an input field which has a label above it and an error text below it, the user needs to be aware that those two text labels are connected to this specific input field.
 
-This can be achieved by following the [Labels or instruction](guideline_understandable_android.md#labels-or-instruction) and [Error identification](guideline_understandable_android.md#error-identification) guidelines.
+This can be achieved by following the [Labels or instruction](guideline_understandable_android.md#labels-or-instructions-wcag-332---level-a) and [Error identification](guideline_understandable_android.md#error-identification-wcag-331---level-a) guidelines.
 
 If multiple UI elements that form a natural group should be displayed on the screen, it is recommended to arrange these elements within a container which is usually a subclass of `ViewGroup`. Also, you should set the container object's `android:screenReaderFocusable` (for devices running Android 8.1. – API level 27) or `android:focusable` to `true`. Furthermore, you should set `android:focusable` attribute of each inner object to `false` because doing so will make accessibility services present the inner element's content descriptions, one after the other, in a single announcement.
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -3,23 +3,62 @@
 
 All content displayed on the screen at some point must be presented to the user in a perceivable manner.
 
-## Text alternatives
+## Text alternatives (WCAG 1.1)
 
 Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.
 
-*This guideline covers point 1.1.1 Non-text Content - Level A of the WCAG standard.*
+### Non-text content identification (WCAG 1.1.1 - Level A)
 
-:white_check_mark: **Success criteria**
+When talking about the screen elements, it is important to make information about all elements accessible and available. Some elements may not have text included by design or as a default user interface component. This can be seen when buttons are used with icons only, images, or other decorative elements.
 
-### Non-text context
+Some users may have issues identifying an element's functionality or description in general, and because of that, it is important to define non-text elements by accessibility features.
+
+✅ **Success criteria**
 
 Each UI element should include a description that describes its purpose. All elements presented on the screen must have the description provided, especially the ones that are important for the screen’s functionality. That way, screen readers such as TalkBack can announce these labels to users who rely on these services.
 
-If an element exists on the UI only for decorative purposes it is recommended that you set its `contentDescription` to "null" or `android:importantForAccessibility` to "no" for devices running Android 4.1 and higher.
+Set `contentDescription` attribute to non-decorative elements. The labels need to be localized, so make sure to use string resources.
 
-:no_entry_sign: **Failure criteria**
+```xml
+<string name='copy'>Copy</string>
 
-- Not providing descriptions of elements presented on the screen that do not exist only for decorative purposes
+<ImageView
+    ...
+    android:contentDescription="@string/copy"/>
+```
+
+If an element exists only for decorative purposes, it is recommended that you set its `contentDescription` to `null` or `android:importantForAccessibility` to `no` for devices running Android 4.1 and higher.
+
+In Compose, use the `contentDescription` parameter to set the description. Some Composables do not offer it as a parameter, in which case it can also be set through `semantics`.
+
+
+```kotlin
+@Composable
+private fun CopyButton(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        Icon(
+            imageVector = Icons.Filled.Copy,
+            contentDescription = stringResource(R.string.copy)
+        )
+    }
+}
+
+@Composable
+private fun MyCustomButton(onClick: () -> Unit) {
+    val copyDescription = stringResource(R.string.copy)
+    Canvas(modifier = Modifier
+        .clickable { onClick() }
+        .semantics { contentDescription = copyDescription }
+    ) { ... }
+}
+```
+
+If an element is used only for decoration, pass `null` for `contentDescription` in order to mark it as non-semantically important.
+
+🚫 **Failure criteria**
+
+- Not providing descriptions of elements presented on the screen that do not exist only for decorative purposes.
+- Setting content description to non-functional or decorative elements. In those cases, labeling the elements may confuse the user and should be avoided.
 
 ---
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -53,8 +53,6 @@ private fun MyCustomButton(onClick: () -> Unit) {
 }
 ```
 
-If an element is used only for decoration, pass `null` for `contentDescription` in order to mark it as non-semantically important.
-
 🚫 **Failure criteria**
 
 - Not providing descriptions of elements presented on the screen that do not exist only for decorative purposes.

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -234,7 +234,7 @@ private fun SongCard(title: String, artist: String) {
 
 _Note 1:_ In cases like these, it is recommended to define content descriptions as concisely as possible, considering that accessibility services will read them one after the other.
 
-_Note 2:_ It is also possible to define a `contentDescription` for the whole group, in which case the descriptions of the children will be ignored. But setting the description for the whole group by aggregating the descriptions of its descendants is not advised, as it is error-prone. For example, if any of the descendants' text changes, the group description will not be updated automatically.
+_Note 2:_ It is also possible to define a `contentDescription` for the whole group, in which case the descriptions of the children will be ignored. But setting the description for the whole group by aggregating the descriptions of its descendants is not advised, as it is error-prone. For example, if any of the descendants' text changes, the group description will not be updated automatically, as explained in the [Developer documentation](https://developer.android.com/guide/topics/ui/accessibility/principles#content-groups).
 
 - Nested groups
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -311,15 +311,18 @@ An example of using `android:accessibilityTraversalBefore` or `android:accessibi
     ...  />
 ```
 
-In apps with minSdk < 22, traversal order can be defined programmatically using ViewCompat:
+In some cases, it might happen that a `View` ignores the statically set property (for example, this problem was observed with `ComposeView`). If that happens, the traversal order can be defined programmatically using `ViewCompat`. It is also the only way to define it in apps with minSdk < 22:
 
 ```kotlin
-ViewCompat.setAccessibilityDelegate(button1, object : AccessibilityDelegateCompat() {
-    override fun onInitializeAccessibilityNodeInfo(host: View?, info: AccessibilityNodeInfoCompat?) {
-        super.onInitializeAccessibilityNodeInfo(host, info)
-        info?.setTraversalAfter(button2)
+ViewCompat.setAccessibilityDelegate(
+    button2,
+    object : AccessibilityDelegateCompat() {
+        override fun onInitializeAccessibilityNodeInfo(host: View?, info: AccessibilityNodeInfoCompat) {
+            super.onInitializeAccessibilityNodeInfo(host, info)
+            info.setTraversalAfter(button3)
+        }
     }
-})
+)
 ```
 
 In Compose, the same can be achieved using `isTraversalGroup` alone or in conjunction with `traversalIndex` semantics.

--- a/docs/guidelines/platforms/android/guideline_understandable_android.md
+++ b/docs/guidelines/platforms/android/guideline_understandable_android.md
@@ -32,19 +32,30 @@ If the application is server-driven and most of the content depends on the backe
 
 Make mobile apps appear and operate in predictable ways.
 
-*This technique covers points 3.2.1 On Focus - Level A & 3.2.2 On Input - Level A of the WCAG standard.*
+### On Focus & On Input (WCAG 3.2.1 and 3.2.2 - Level A)
 
-### On Focus & On Input
+Receiving focus on or interacting with any component should not initiate a change of context unless previously announced.
 
-:white_check_mark: **Success criteria**
+✅ **Success criteria**
 
-The user should be able to navigate through the app without constant context switching. Also, interacting with the view should not cause a change of context. If view interaction changes the context, that should be signalized to the user **before** the interaction.
+Users need to be able to consume content without any sudden interruptions or changes in context. Interacting with any UI component doesn't automatically cause a change of context unless the user has been previously advised of the behavior _before_ using the component.
 
-If the content displayed on the screen is designed and implemented following [Perceivable guidelines](https://github.com/infinum/accessibility-mobile-standards/blob/master/docs/guidelines/platforms/android/guideline_percievable_android.md), these requirements should be met by default.
+Changes of focus and, thus, context should only ever be done intentionally and consciously.
 
-:no_entry_sign: **Failure criteria**
+Whenever adding a custom callback to a focus or input change event, think about whether the action that will be executed can be considered a change of context and, if so, could the user have expected it before initiating focus/input change.
 
-- The content is not grouped based on context relationships and has no meaningful labels defined.
+Here are some examples of focus/input callbacks that would be acceptable with respect to this criteria:
+- An app for online shopping includes a form with payment and delivery information. Below payment information, there is a radio button group with options "Delivery address is the same as the payment information" and "I want products delivered to another address". If the user selects the latter option, a new input field for the delivery address appears. This is not considered a change of context, because only some parts of the screen changed, but the overall structure remained the same.
+- A theme settings screen has three radio buttons (light/dark/system) and instructions to the user that the theme will be changed immediately upon selecting an option. There is no "Submit" button and the action is executed upon input, but the user is clearly instructed on what to expect. 
+- In an input field, a trailing action appears when the input field gets focus. For example, in a password input field, a button for toggling password visibility appears when the field gets focus. This is considered acceptable, as the user is just presented with additional actions and the overall context did not change at all.
+- In an input field, a trailing action for clearing the entire input appears when the user enters something into the field.
+
+
+🚫 **Failure examples**
+
+Some examples of actions that _are_ considered a change of context and would violate the criteria are:
+- Automatically submitting a form when a certain field gets focus or input. For example, in a login form, the user is automatically logged in when checking the "Remember me" checkbox, without pressing the "Log in" button.
+- Showing an alert dialogs when an element receives focus. For example, an input field receives focus and a help alert dialog describing a field appears. The user would first have to close the dialog before continuing with input, and the dialog would appear any time the user might want to edit their input.
 
 ---
 

--- a/docs/guidelines/principles/guideline_checklist.md
+++ b/docs/guidelines/principles/guideline_checklist.md
@@ -38,22 +38,22 @@ Guidelines mentioned in this section are related to the user interface and exper
 
 Guidelines mentioned in this section are related to the screen reader and interaction with the application. These guidelines contain technical, but also design and content-related information which should be implemented in collaboration with other teams (based on required inputs).
 
-- [ ] 1.1.1 Non-text content (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#non-text-content-identification-wcag-111---level-a) | Flutter
-- [ ] 1.3.1 Info and relationships (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#element-information-and-relationship-wcag-131---level-a) | Flutter
-- [ ] 1.3.2 Meaningful sequence (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#meaningful-sequence-wcag-132---level-a) | Flutter
+- [ ] 1.1.1 Non-text content (A) - [Android](../platforms/android/guideline_percievable_android.md#non-text-content-identification-wcag-111---level-a) | [iOS](../platforms/ios/guideline_perceivable_ios.md#non-text-content-identification-wcag-111---level-a) | Flutter
+- [ ] 1.3.1 Info and relationships (A) - [Android](../platforms/android/guideline_percievable_android.md#info-and-relationships-wcag-131---level-a) | [iOS](../platforms/ios/guideline_perceivable_ios.md#element-information-and-relationship-wcag-131---level-a) | Flutter
+- [ ] 1.3.2 Meaningful sequence (A) - [Android](../platforms/android/guideline_percievable_android.md#meaningful-sequence-wcag-132---level-a) | [iOS](../platforms/ios/guideline_perceivable_ios.md#meaningful-sequence-wcag-132---level-a) | Flutter
 - [ ] 1.3.5 Identify input purpose (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#identify-input-purpose-wcag-135---level-aa) | Flutter
 - [ ] 1.4.10 Reflow (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#reflow-wcag-1410---level-aa) | Flutter
-- [ ] 2.4.1 Bypass blocks (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#bypass-blocks-wcag-241---level-a) | Flutter
+- [ ] 2.4.1 Bypass blocks (A) - [Android](../platforms/android/guideline_operable_android.md#bypass-blocks-wcag-241---level-a) | [iOS](../platforms/ios/guideline_operable_ios.md#bypass-blocks-wcag-241---level-a) | Flutter
 - [ ] 2.4.2 Page titled (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#page-titled-wcag-242---level-a) | Flutter
-- [ ] 2.4.3 Focus order (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#focus-order-wcag-243---level-a) | Flutter
+- [ ] 2.4.3 Focus order (A) - [Android](../platforms/android/guideline_operable_android.md#focus-order-wcag-243---level-a) | [iOS](../platforms/ios/guideline_operable_ios.md#focus-order-wcag-243---level-a) | Flutter
 - [ ] 2.4.4 Link purpose (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#action-purpose-wcag-244---level-a) | Flutter
 - [ ] 2.4.5 Multiple ways (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#other-operable-guidelines) | Flutter
 - [ ] 2.4.6 Headings and labels (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#heading-and-labels-wcag-246---level-aa) | Flutter
 - [ ] 2.4.7 Focus visible (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#focus-visibility-wcag-247---level-aa) | Flutter
 - [ ] 2.4.11 Focus not obstructed (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#focus-not-obscured-minimum-wcag-2411---level-aa) | Flutter
 - [ ] 2.5.3 Label in name (A)  - Android | [iOS](../platforms/ios/guideline_operable_ios.md#label-in-name-wcag-253---level-a) | Flutter
-- [ ] 3.2.1 On focus (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#on-focus--on-input-wcag-321-and-322---level-a) | Flutter
-- [ ] 3.2.2 On input (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#on-focus--on-input-wcag-321-and-322---level-a) | Flutter
+- [ ] 3.2.1 On focus (A) - [Android](../platforms/android/guideline_understandable_android.md#on-focus--on-input-wcag-321-and-322---level-a) | [iOS](../platforms/ios/guideline_understandable_ios.md#on-focus--on-input-wcag-321-and-322---level-a) | Flutter
+- [ ] 3.2.2 On input (A) - [Android](../platforms/android/guideline_understandable_android.md#on-focus--on-input-wcag-321-and-322---level-a) | [iOS](../platforms/ios/guideline_understandable_ios.md#on-focus--on-input-wcag-321-and-322---level-a) | Flutter
 - [ ] 3.2.3 Consistent navigation (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#consistent-navigation-wcag-323---level-aa) | Flutter
 - [ ] 3.2.4 Consistent identification (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#consistent-identification-wcag-324---level-aa) | Flutter
 - [ ] 3.3.1 Error identification (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#error-identification-wcag-331---level-a) | Flutter


### PR DESCRIPTION
Updated Level A chapters listed in
- #40

Since all of the chapters are inside one issue, I decided to split them into Level A & AA, so it's at least a little bit easier to review.

I updated some of the chapters with additional information that are included in the iOS part + some additional explanations where I remembered needing them when first going through the guidelines. Other than that, it's mostly adding Compose examples.

Also, some of the links point directly to specific chapters/guidelines. There is a a chance they'll break once everything is merged 😬 but I'll go through them once again before merging and fix if needed.
I tried to avoid copy/pasting and instead referencing to the already existing chapters, but please let me know if I missed anything and we have duplicates.