### PR TITLE
Android guidelines - Navigation through components and screens - Level AA

### DIFF
--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -282,6 +282,16 @@ The example given in the **Screenshot 4.** - **Avoid using ClickableSpan** and i
 
 ---
 
+### Focus Visibility (WCAG 2.4.7 - Level AA)
+
+This guideline states that the user should be able to see the focus on the element that is currently selected. With a mobile platform in mind, this guideline is automatically satisfied when TalkBack or Switch access is used --- the focus is made clearly visible with colored borders.
+
+#### ✅ Success technique(s)
+
+Even though the system automatically handles this, think about selection and focus on custom elements; make sure that the focus is visible in the correct way and that the user can see which element is currently selected, especially if the component contains "inner" elements. If there are too many nested focusable elements and it is difficult to determine which one is in focus, this might call for a reconsideration in design, where the elements could be laid out in a different way.
+
+---
+
 #### Sources
 
 - [Google Support Page](https://support.google.com/accessibility/android)

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -292,6 +292,27 @@ Even though the system automatically handles this, think about selection and foc
 
 ---
 
+### Focus Not Obscured (Minimum) (WCAG 2.4.11 - Level AA)
+
+When the user navigates through the app, the focus should not be obscured by any other author-created elements and should be visible, at least partially.
+
+#### ✅ Success technique(s)
+
+When creating a view or a screen, think about the visibility of the focus and make sure that the user can see which element is currently selected.
+
+To satisfy this guideline, check the following:
+
+- The content is scrollable (when needed)
+- The element is not obscured by other elements
+- The element is (at least) partially visible when focused/used
+
+#### 🚫 Failures
+
+The following should be avoided:
+
+- Element is hidden due to inability to scroll.
+- Another element of the screen (e.g. sticky footer or floating element) hides the focused element.
+
 ### Other operable guidelines
 
 This section contains guidelines that may not applicable for the mobile (Android) platform, or its criteria is a not the responsibility of the mobile team. Still, take into account that those guidelines needs to be satisfied.

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -288,7 +288,10 @@ This guideline states that the user should be able to see the focus on the eleme
 
 #### ✅ Success technique(s)
 
-Even though the system automatically handles this, think about selection and focus on custom elements; make sure that the focus is visible in the correct way and that the user can see which element is currently selected, especially if the component contains "inner" elements. If there are too many nested focusable elements and it is difficult to determine which one is in focus, this might call for a reconsideration in design, where the elements could be laid out in a different way.
+Even though the system automatically handles this, think about selection and focus on custom elements; make sure that the focus is visible in the correct way and that the user can see which element is currently selected, especially if the component contains "inner" elements.
+
+#### 🚫 Failure examples
+- There are too many nested focusable elements and it is difficult to determine which one is in focus. This primarily might call for a reconsideration in design, where the elements could be laid out in a different way.
 
 ---
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -292,6 +292,14 @@ Even though the system automatically handles this, think about selection and foc
 
 ---
 
+### Other operable guidelines
+
+This section contains guidelines that may not applicable for the mobile (Android) platform, or its criteria is a not the responsibility of the mobile team. Still, take into account that those guidelines needs to be satisfied.
+
+- [WCAG 2.4.5 Multiple Ways - Level AA](https://www.w3.org/WAI/WCAG22/quickref/#multiple-ways)
+
+---
+
 #### Sources
 
 - [Google Support Page](https://support.google.com/accessibility/android)

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -291,6 +291,33 @@ The content provided in your app must be easily understandable to all users. Tha
 
 ---
 
+## Distinguishable (WCAG 1.4)
+
+### Reflow (WCAG 1.4.10 - Level AA)
+
+The reflow is basically another name for responsible design in this context. The content should be able to reflow from one screen size to another without losing information or functionality.
+
+#### ✅ Success criteria
+
+Every component on the screen should be able to reflow from one screen size to another, without any content disappearing or becoming obscured. The same applies when the device orientation is changed or the content is enlarged in any way (increased font or display size in the device settings).
+
+The above can be achieved by using:
+- Components with variable size (i.e. by not restricting the maximum height/width).
+- Scrollable containers when content is laid out linearly. In XML, use `ScrollView` (or `NestedScrollView`) for any content that can potentially go off screen on smaller screen sizes. In Compose, the same can be achieved by using a `LazyColumn/Row` or just a regular `Column/Row` with a `vertical/horizontalScroll()` modifier if lazy behavior is not needed.
+- Layouts that allow the content to flow and wrap into multiple lines if it becomes too wide to fit the screen. In XML, this can be achieved by using the [`Flow`](https://developer.android.com/reference/androidx/constraintlayout/helper/widget/Flow) layout. In Compose, there are [`FlowRow/Column`](https://developer.android.com/develop/ui/compose/layouts/flow) for the same purpose.
+
+For additional techniques regarding text scaling, see the [Resize text guideline](guideline_percievable_android.md#resize-text).
+
+This should not be done only on the screen level, but also on the component level. Every component should be able to reflow from one size to another without losing information or functionality (e.g. buttons, labels, images, etc.).
+
+The content should also never become scrollable in both directions --- having scrolling in both directions on one screen is permitted, but not for one single piece of content (e.g. a block of text). Luckily, this is not likely to happen due to the behavior of native layouts and components, but it should still be kept in mind.
+
+#### 🚫 Failure criteria
+
+Content becomes unusable on a device with a smaller screen, when changing the orientation or when increasing font/display size. For example, the elements go off the screen, start overlapping or important parts of some text are cut off (e.g. ellipsized).
+
+---
+
 #### Sources
 
 - [Google Support Page](https://support.google.com/accessibility/android)

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -304,7 +304,7 @@ Every component on the screen should be able to reflow from one screen size to a
 The above can be achieved by using:
 - Components with variable size (i.e. by not restricting the maximum height/width).
 - Scrollable containers when content is laid out linearly. In XML, use `ScrollView`, `NestedScrollView` or a `RecyclerView` for any content that can potentially go off screen on smaller screen sizes. In Compose, the same can be achieved by using a `LazyColumn/Row` or just a regular `Column/Row` with a `vertical/horizontalScroll()` modifier if lazy behavior is not needed.
-- Layouts that allow the content to flow and wrap into multiple lines if it becomes too wide to fit the screen. In XML, this can be achieved by using the [`Flow`](https://developer.android.com/reference/androidx/constraintlayout/helper/widget/Flow) layout. In Compose, there are [`FlowRow/Column`](https://developer.android.com/develop/ui/compose/layouts/flow) for the same purpose.
+- Layouts that allow the content to flow and wrap into multiple lines if it becomes too wide to fit the screen. In XML, this can be achieved by using the [`Flow`](https://developer.android.com/reference/androidx/constraintlayout/helper/widget/Flow) layout. In Compose, there are [`FlowRow/Column`](https://developer.android.com/develop/ui/compose/layouts/flow) for the same purpose. Do note that the flow layouts were added only in version 1.4 and are still experimental in Compose, so expect possible API changes.
 
 For additional techniques regarding text scaling, see the [Resize text guideline](guideline_percievable_android.md#resize-text).
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -428,7 +428,7 @@ The above can be achieved by using:
 - Scrollable containers when content is laid out linearly. In XML, use `ScrollView`, `NestedScrollView` or a `RecyclerView` for any content that can potentially go off screen on smaller screen sizes. In Compose, the same can be achieved by using a `LazyColumn/Row` or just a regular `Column/Row` with a `vertical/horizontalScroll()` modifier if lazy behavior is not needed.
 - Layouts that allow the content to flow and wrap into multiple lines if it becomes too wide to fit the screen. In XML, this can be achieved by using the [`Flow`](https://developer.android.com/reference/androidx/constraintlayout/helper/widget/Flow) layout. In Compose, there are [`FlowRow/Column`](https://developer.android.com/develop/ui/compose/layouts/flow) for the same purpose. Do note that the flow layouts were added only in version 1.4 and are still experimental in Compose, so expect possible API changes.
 
-For additional techniques regarding text scaling, see the [Resize text guideline](guideline_percievable_android.md#resize-text).
+For additional techniques regarding text scaling, see the [Resize text guideline](guideline_percievable_android.md#resizeable-text-wcag-144---level-aa).
 
 This should not be done only on the screen level, but also on the component level. Every component should be able to reflow from one size to another without losing information or functionality (e.g. buttons, labels, images, etc.).
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -303,7 +303,7 @@ Every component on the screen should be able to reflow from one screen size to a
 
 The above can be achieved by using:
 - Components with variable size (i.e. by not restricting the maximum height/width).
-- Scrollable containers when content is laid out linearly. In XML, use `ScrollView` (or `NestedScrollView`) for any content that can potentially go off screen on smaller screen sizes. In Compose, the same can be achieved by using a `LazyColumn/Row` or just a regular `Column/Row` with a `vertical/horizontalScroll()` modifier if lazy behavior is not needed.
+- Scrollable containers when content is laid out linearly. In XML, use `ScrollView`, `NestedScrollView` or a `RecyclerView` for any content that can potentially go off screen on smaller screen sizes. In Compose, the same can be achieved by using a `LazyColumn/Row` or just a regular `Column/Row` with a `vertical/horizontalScroll()` modifier if lazy behavior is not needed.
 - Layouts that allow the content to flow and wrap into multiple lines if it becomes too wide to fit the screen. In XML, this can be achieved by using the [`Flow`](https://developer.android.com/reference/androidx/constraintlayout/helper/widget/Flow) layout. In Compose, there are [`FlowRow/Column`](https://developer.android.com/develop/ui/compose/layouts/flow) for the same purpose.
 
 For additional techniques regarding text scaling, see the [Resize text guideline](guideline_percievable_android.md#resize-text).

--- a/docs/guidelines/platforms/android/guideline_understandable_android.md
+++ b/docs/guidelines/platforms/android/guideline_understandable_android.md
@@ -111,6 +111,26 @@ If the content displayed on the screen is designed and implemented following [Pe
 :no_entry_sign: **Failure criteria**
 
 - The content is not grouped based on context relationships and has no meaningful labels defined.
+---
+
+### Consistent Navigation (WCAG 3.2.3 - Level AA)
+
+For users, it is important to have a consistent navigation experience throughout the app (on all screens). With that satisfied, users can easily predict where they are and where they can go next.
+
+#### ✅ Success criteria
+
+To satisfy this criterion, try to keep the navigation structure consistent, with elements like the toolbar, bottom navigation, search bar or any other repeated elements always in the same place, read out in the same order and with the same functionality.
+
+Visually, this is mostly the responsibility of the design, but it is important to make sure that consistent ordering is preserved when using assistive technologies (e.g. TalkBack) as well.
+
+If there is a need to manually adjust ordering of elements to make them consistent across multiple screens, the same techniques described in [Meaningful sequence guideline](guideline_percievable_android.md#meaningful-sequence-wcag-132---level-a) can be applied.
+
+#### 🚫 Failure examples
+
+Usually, when reusing the same components across multiple screens, the ordering will be preserved automatically. However, there are certain cases where other elements might come "in-between" and there could be some inconsistencies when mixing technologies on the same screen (e.g. the toolbar is a `View`, while all of the other screen contents are in Compose), so pay special attention to those.
+ 
+- TalkBack: Two screens share the same bottom navigation bar. On the first screen, the bottom bar items are read out last, after all the other content. On the second screen, the bottom bar items are read out after the toolbar and before any other screen content.
+- TalkBack: An app has multiple screens that contain a toolbar with a title and a navigation button. On some screens, the navigation button is read out first and, on others, the title is read out before the navigation button.
 
 ---
 

--- a/docs/guidelines/principles/guideline_checklist.md
+++ b/docs/guidelines/principles/guideline_checklist.md
@@ -42,19 +42,19 @@ Guidelines mentioned in this section are related to the screen reader and intera
 - [ ] 1.3.1 Info and relationships (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#element-information-and-relationship-wcag-131---level-a) | Flutter
 - [ ] 1.3.2 Meaningful sequence (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#meaningful-sequence-wcag-132---level-a) | Flutter
 - [ ] 1.3.5 Identify input purpose (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#identify-input-purpose-wcag-135---level-aa) | Flutter
-- [ ] 1.4.10 Reflow (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#reflow-wcag-1410---level-aa) | Flutter
+- [ ] 1.4.10 Reflow (AA) - [Android](../platforms/android/guideline_percievable_android.md#reflow-wcag-1410---level-aa) | [iOS](../platforms/ios/guideline_perceivable_ios.md#reflow-wcag-1410---level-aa) | Flutter
 - [ ] 2.4.1 Bypass blocks (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#bypass-blocks-wcag-241---level-a) | Flutter
 - [ ] 2.4.2 Page titled (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#page-titled-wcag-242---level-a) | Flutter
 - [ ] 2.4.3 Focus order (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#focus-order-wcag-243---level-a) | Flutter
 - [ ] 2.4.4 Link purpose (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#action-purpose-wcag-244---level-a) | Flutter
-- [ ] 2.4.5 Multiple ways (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#other-operable-guidelines) | Flutter
+- [ ] 2.4.5 Multiple ways (AA) - [Android](../platforms/android/guideline_operable_android.md#other-operable-guidelines) | [iOS](../platforms/ios/guideline_operable_ios.md#other-operable-guidelines) | Flutter
 - [ ] 2.4.6 Headings and labels (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#heading-and-labels-wcag-246---level-aa) | Flutter
-- [ ] 2.4.7 Focus visible (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#focus-visibility-wcag-247---level-aa) | Flutter
-- [ ] 2.4.11 Focus not obstructed (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#focus-not-obscured-minimum-wcag-2411---level-aa) | Flutter
+- [ ] 2.4.7 Focus visible (AA) - [Android](../platforms/android/guideline_operable_android.md#focus-visibility-wcag-247---level-aa) | [iOS](../platforms/ios/guideline_operable_ios.md#focus-visibility-wcag-247---level-aa) | Flutter
+- [ ] 2.4.11 Focus not obstructed (AA) - [Android](../platforms/android/guideline_operable_android.md#focus-not-obscured-minimum-wcag-2411---level-aa) | [iOS](../platforms/ios/guideline_operable_ios.md#focus-not-obscured-minimum-wcag-2411---level-aa) | Flutter
 - [ ] 2.5.3 Label in name (A)  - Android | [iOS](../platforms/ios/guideline_operable_ios.md#label-in-name-wcag-253---level-a) | Flutter
 - [ ] 3.2.1 On focus (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#on-focus--on-input-wcag-321-and-322---level-a) | Flutter
 - [ ] 3.2.2 On input (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#on-focus--on-input-wcag-321-and-322---level-a) | Flutter
-- [ ] 3.2.3 Consistent navigation (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#consistent-navigation-wcag-323---level-aa) | Flutter
+- [ ] 3.2.3 Consistent navigation (AA) - [Android](../platforms/android/guideline_understandable_android.md#consistent-navigation-wcag-323---level-aa) | [iOS](../platforms/ios/guideline_understandable_ios.md#consistent-navigation-wcag-323---level-aa) | Flutter
 - [ ] 3.2.4 Consistent identification (AA) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#consistent-identification-wcag-324---level-aa) | Flutter
 - [ ] 3.3.1 Error identification (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#error-identification-wcag-331---level-a) | Flutter
 - [ ] 3.3.2 Labels or instructions (A) - Android | [iOS](../platforms/ios/guideline_understandable_ios.md#labels-or-instructions-wcag-332---level-a) | Flutter


### PR DESCRIPTION
Updated Level AA chapters listed in
- #40

Since all of the chapters are inside one issue, I decided to split them into Level A & AA, so it's at least a little bit easier to review.

Also, some of the links point directly to specific chapters/guidelines. There is a a chance they'll break once everything is merged 😬 but I'll go through them once again before merging and fix if needed.
I tried to avoid copy/pasting and instead referencing to the already existing chapters, but please let me know if I missed anything and we have duplicates.