### PR TITLE
[WCAG 2.5.8] Update target sizes per new requirements

### DIFF
--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -338,7 +338,7 @@ IconButton(
     // Content of the IconButton goes here
 }
 ```
-More about success criterion can be found on the [official WCAG page](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
+More about success criterion, and also some **exceptions** regarding this rule, can be found on the [official WCAG page](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
 Additionally, implementation details can be found in the [official Android documentation](https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls).
 
 _Important to note is that this guideline primarily depends on accessible design._

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -280,6 +280,10 @@ The example given in the **Screenshot 4.** - **Avoid using ClickableSpan** and i
 
 - The link is part of the longer text and implemented using ClickableSpan, so TalkBack users are not aware of the link’s existence.
 
+## Input Modalities
+
+_Make it easier for users to operate functionality through various inputs beyond keyboard._
+
 ### Target size (Minimum) (WCAG 2.5.8 - Level AA)
 
 To make your app's interface more user-friendly, ensure that controls are easy to see and tap. A bigger target size is also essential to make your app accessible to everyone, including users with disabilities.

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -283,13 +283,14 @@ The example given in the **Screenshot 4.** - **Avoid using ClickableSpan** and i
 ### Target size (Minimum) (WCAG 2.5.8 - Level AA)
 
 To make your app's interface more user-friendly, ensure that controls are easy to see and tap. A bigger target size is also essential to make your app accessible to everyone, including users with disabilities.
-More details about this guideline can be found [here](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
+
+> This guideline covers point *2.5.8 Target Size (Minimum) - Level AA of the WCAG standard.*
 
 :white_check_mark: **Success criteria**
 
-This guideline primarily addresses design considerations. However, it is important that from the development side, the application provide enough space for the elements to be easily operable by touch.
+It is important that the application provides enough space for the elements to be easily operable by touch.
 
-As per official Android documentation, recommended minimum touch target size is 48x48 dp for each interactive UI element, though larger sizes can further improve usability. 
+As per official Android documentation, the recommended minimum touch target size is 48x48 dp for each interactive UI element, though larger sizes can further improve usability.
 
 **Code example:**
 
@@ -316,7 +317,10 @@ IconButton(
     // Content of the IconButton goes here
 }
 ```
-More about the implementation details can be found [here](https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls).
+More about success criterion can be found on the [official WCAG page](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
+Additionally, implementation details can be found in the [official Android documentation](https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls).
+
+_Important to note is that this guideline primarily depends on accessible design._
 
 :no_entry_sign: **Failure criteria**
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -280,6 +280,48 @@ The example given in the **Screenshot 4.** - **Avoid using ClickableSpan** and i
 
 - The link is part of the longer text and implemented using ClickableSpan, so TalkBack users are not aware of the link’s existence.
 
+### Target size (Minimum) (WCAG 2.5.8 - Level AA)
+
+To make your app's interface more user-friendly, ensure that controls are easy to see and tap. A bigger target size is also essential to make your app accessible to everyone, including users with disabilities.
+More details about this guideline can be found [here](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
+
+:white_check_mark: **Success criteria**
+
+This guideline primarily addresses design considerations. However, it is important that from the development side, the application provide enough space for the elements to be easily operable by touch.
+
+As per official Android documentation, recommended minimum touch target size is 48x48 dp for each interactive UI element, though larger sizes can further improve usability. 
+
+**Code example:**
+
+- In xml layout file:
+```
+<ImageButton ...
+    android:paddingLeft="4dp"
+    android:minWidth="40dp"
+    android:paddingRight="4dp"
+
+    android:paddingTop="8dp"
+    android:minHeight="32dp"
+    android:paddingBottom="8dp" />
+```
+
+- In Compose:
+```kotlin
+IconButton(
+    modifier = Modifier
+        .padding(start = 4.dp, end = 4.dp, top = 8.dp, bottom = 8.dp)
+        .defaultMinSize(minWidth = 40.dp, minHeight = 32.dp),
+    // Add your onClick or other parameters here
+) {
+    // Content of the IconButton goes here
+}
+```
+More about the implementation details can be found [here](https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls).
+
+:no_entry_sign: **Failure criteria**
+
+- Interactive UI elements are too small to be easily tapped.
+
 ---
 
 #### Sources

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -338,8 +338,10 @@ IconButton(
     // Content of the IconButton goes here
 }
 ```
+
+In the previous examples, the target size is calculated as the sum of minimal width/height (since those properties define the minimal size of the content area of the view) and paddings. More implementation details can be found in the [official Android documentation](https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls).
+
 More about success criterion, and also some **exceptions** regarding this rule, can be found on the [official WCAG page](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
-Additionally, implementation details can be found in the [official Android documentation](https://developer.android.com/guide/topics/ui/accessibility/apps#large-controls).
 
 _Important to note is that this guideline primarily depends on accessible design._
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -290,9 +290,9 @@ To make your app's interface more user-friendly, ensure that controls are easy t
 
 > This guideline covers point *2.5.8 Target Size (Minimum) - Level AA of the WCAG standard.*
 
-:white_check_mark: **Success criteria**
+:white_check_mark: **Success technique(s)**
 
-It is important that the application provides enough space for the elements to be easily operable by touch.
+The application must provide enough space for the elements to be easily operable by touch.
 
 As per official Android documentation, the recommended minimum touch target size is 48x48 dp for each interactive UI element, though larger sizes can further improve usability.
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -297,7 +297,7 @@ The example given in the **Screenshot 4.** - **Avoid using ClickableSpan** and i
 
 - The link is part of the longer text and implemented using ClickableSpan, so TalkBack users are not aware of the link’s existence.
 
-## Input Modalities
+## Input Modalities (WCAG 2.5)
 
 _Make it easier for users to operate functionality through various inputs beyond keyboard._
 

--- a/docs/guidelines/principles/guideline_checklist.md
+++ b/docs/guidelines/principles/guideline_checklist.md
@@ -32,7 +32,7 @@ Guidelines mentioned in this section are related to the user interface and exper
 - [ ] 2.3.1 Three flashes or below threshold (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#three-flashed-or-below-threshold-wcag-231---level-a) | Flutter
 - [ ] 2.5.4 Motion actuation (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#motion-actuation-wcag-254---level-a) | Flutter
 - [ ] 2.5.7 Dragging movements (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#dragging-movements-wcag-257---level-aa) | Flutter
-- [ ] 2.5.8 Target size (minimum) (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#target-size-minimum-wcag-258---level-aa) | Flutter
+- [ ] 2.5.8 Target size (minimum) (AA) - [Android](../platforms/android/guideline_operable_android.md#target-size-minimum-wcag-258---level-aa) | [iOS](../platforms/ios/guideline_operable_ios.md#target-size-minimum-wcag-258---level-aa) | Flutter
 
 ## Screen reader & interaction
 


### PR DESCRIPTION
**Description:**

Added changes closes #39 
- introduced a new section for Input modalities including guidelines for minimum target size

Just a note—to me, this guideline seems very dependent on the accessible design, but I decided to add it anyway since the official Android documentation also mentions it. I added a sentence at the end of the section stressing this dependency. 
Feel free to share if you think this section should be removed or have any other ideas or suggestions. 
