### PR TITLE
[WCAG 1.4.1] Update colors per new requirements

### DIFF
--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -116,7 +116,7 @@ Moving, blinking, or scrolling, or auto-updating content in the app.
 
 ---
 
-## Seizures and Physical Reactions
+## Seizures and Physical Reactions (WCAG 2.3.1 - Level A)
 
 Do not design content in a way that is known to cause seizures or physical reactions.
 
@@ -132,7 +132,7 @@ Apps should not contain elements that flash more than three times in one second.
 
 - If using flashing content, keep the flash of an element running for a minimum of 333ms.
 
-- If using of an element that flashes more frequently is unavoidable, make sure that the flashing area covers less than 25% within 10 degrees of a visual field.
+- If using an element that flashes more frequently is unavoidable, make sure that the flashing area covers less than 25% within 10 degrees of a visual field.
 
 #### 🚫 Failures
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -124,7 +124,7 @@ Do not design content in a way that is known to cause seizures or physical react
 
 Apps should not contain elements that flash more than three times in one second.
 
-*This guideline covers point 2.3.1 - Level A of the WCAG standard.*
+> This guideline covers _2.3.1 - Level A of the WCAG standard._
 
 #### ✅ Success technique(s)
 

--- a/docs/guidelines/platforms/android/guideline_operable_android.md
+++ b/docs/guidelines/platforms/android/guideline_operable_android.md
@@ -159,11 +159,11 @@ Moving, blinking, or scrolling, or auto-updating content in the app.
 
 ---
 
-## Seizures and Physical Reactions (WCAG 2.3.1 - Level A)
+## Seizures and Physical Reactions (WCAG 2.3)
 
 Do not design content in a way that is known to cause seizures or physical reactions.
 
-### Three Flashed or Below Threshold
+### Three Flashed or Below Threshold (WCAG 2.3.1 - Level A)
 
 Apps should not contain elements that flash more than three times in one second.
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -301,11 +301,11 @@ Make sure that color isn't the only visual cue used for conveying information, i
 
 > This guideline covers _1.4.1 Use of Color - Level A of the WCAG standard._
 
-:white_check_mark: **Success criteria**
+:white_check_mark: **Success technique(s)**
 
 [Use cues or symbols rather than colors to distinguish different views and different actions](https://developer.android.com/guide/topics/ui/accessibility/principles#cues-other-than-color) that those views provide. That way, users with color vision deficiencies could also easily understand the whole UI.
 
-:no_entry_sign: **Failure criteria**
+:no_entry_sign: **Failures**
 
 - An important difference between elements is stressed only with colors.
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -435,7 +435,7 @@ _Important to note is that this guideline primarily depends on accessible design
 
 ## Other perceivable guidelines
 
-This section includes guidelines that may not apply to the Android platform or fall under the mobile team’s responsibilities. However, please keep in mind that these guidelines still need to be met."
+This section includes guidelines that may not apply to the Android platform or fall under the mobile team’s responsibilities. However, please keep in mind that these guidelines still need to be met.
 
 - [WCAG 1.4.3 Contrast (Minimum) - Level AA](https://www.w3.org/WAI/WCAG22/quickref/#contrast-minimum) - This guideline completely depends on the accessible design
 

--- a/docs/guidelines/platforms/android/guideline_percievable_android.md
+++ b/docs/guidelines/platforms/android/guideline_percievable_android.md
@@ -291,6 +291,32 @@ The content provided in your app must be easily understandable to all users. Tha
 
 ---
 
+## Distinguishable (WCAG 1.4)
+
+_Make it easier for users to see and hear content including separating foreground from background._
+
+### Use of Color (WCAG 1.4.1 - Level A)
+
+Make sure that color isn't the only visual cue used for conveying information, indicating actions, prompting responses, or distinguishing elements. This is important to ensure that users with disabilities also have a clear and accessible understanding of the app's content.
+
+> This guideline covers _1.4.1 Use of Color - Level A of the WCAG standard._
+
+:white_check_mark: **Success criteria**
+
+[Use cues or symbols rather than colors to distinguish different views and different actions](https://developer.android.com/guide/topics/ui/accessibility/principles#cues-other-than-color) that those views provide. That way, users with color vision deficiencies could also easily understand the whole UI.
+
+:no_entry_sign: **Failure criteria**
+
+- An important difference between elements is stressed only with colors.
+
+_Important to note is that this guideline primarily depends on accessible design._
+
+## Other perceivable guidelines
+
+This section includes guidelines that may not apply to the Android platform or fall under the mobile team’s responsibilities. However, please keep in mind that these guidelines still need to be met."
+
+- [WCAG 1.4.3 Contrast (Minimum) - Level AA](https://www.w3.org/WAI/WCAG22/quickref/#contrast-minimum) - This guideline completely depends on the accessible design
+
 #### Sources
 
 - [Google Support Page](https://support.google.com/accessibility/android)

--- a/docs/guidelines/principles/guideline_checklist.md
+++ b/docs/guidelines/principles/guideline_checklist.md
@@ -20,7 +20,7 @@ Guidelines mentioned in this section are related to the user interface and exper
 
 - [ ] 1.3.3 Sensory characteristics (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#sensory-characteristics-wcag-133---level-a) | Flutter
 - [ ] 1.3.4 Orientation (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#orientation-wcag-134---level-aa) | Flutter
-- [ ] 1.4.1 Use of color (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
+- [ ] 1.4.1 Use of color (A) - [Android](../platforms/android/guideline_percievable_android.md#use-of-color-wcag-141---level-a) | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 1.4.2 Audio control (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 1.4.3 Contrast (minimum) (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 1.4.4 Resize text (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#resizeable-text-wcag-144---level-aa) | Flutter

--- a/docs/guidelines/principles/guideline_checklist.md
+++ b/docs/guidelines/principles/guideline_checklist.md
@@ -22,14 +22,14 @@ Guidelines mentioned in this section are related to the user interface and exper
 - [ ] 1.3.4 Orientation (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#orientation-wcag-134---level-aa) | Flutter
 - [ ] 1.4.1 Use of color (A) - [Android](../platforms/android/guideline_percievable_android.md#use-of-color-wcag-141---level-a) | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 1.4.2 Audio control (A) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
-- [ ] 1.4.3 Contrast (minimum) (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
+- [ ] 1.4.3 Contrast (minimum) (AA) - [Android](../platforms/android/guideline_percievable_android.md#other-perceivable-guidelines) | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 1.4.4 Resize text (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#resizeable-text-wcag-144---level-aa) | Flutter
 - [ ] 1.4.5 Images of text (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#images-of-text-wcag-145---level-aa) | Flutter
 - [ ] 1.4.11 Non-text contrast (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 1.4.12 Text spacing (AA) - Android | [iOS](../platforms/ios/guideline_perceivable_ios.md#other-perceivable-guidelines) | Flutter
 - [ ] 2.2.1 Timing adjustable (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#timing-adjustable-wcag-221---level-a) | Flutter
 - [ ] 2.2.2 Pause, stop, hide (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#pause-stop-hide-wcag-222---level-a) | Flutter
-- [ ] 2.3.1 Three flashes or below threshold (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#three-flashed-or-below-threshold-wcag-231---level-a) | Flutter
+- [ ] 2.3.1 Three flashes or below threshold (A) - [Android](../platforms/android/guideline_operable_android.md#seizures-and-physical-reactions-wcag-231---level-a) | [iOS](../platforms/ios/guideline_operable_ios.md#three-flashed-or-below-threshold-wcag-231---level-a) | Flutter
 - [ ] 2.5.4 Motion actuation (A) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#motion-actuation-wcag-254---level-a) | Flutter
 - [ ] 2.5.7 Dragging movements (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#dragging-movements-wcag-257---level-aa) | Flutter
 - [ ] 2.5.8 Target size (minimum) (AA) - Android | [iOS](../platforms/ios/guideline_operable_ios.md#target-size-minimum-wcag-258---level-aa) | Flutter


### PR DESCRIPTION
**Description:**

Added changes close #34 :
- 1.4.1 - Added _Use of colors section_ even though the guideline is dependant on accessible design since the same is mentioned in the official Android docs
- 1.4.3 - Minimum contrast guideline should be satisfied on the design level and there are no specifics for Android there so I've added it to the "others" section
- 2.3.1 - the section already existed so I just unified the title with the latest changes

Feel free to share if you think any of the sections should be removed or have any other ideas or suggestions.